### PR TITLE
add elementinfo plot and remove unnecessary parametrization of functions

### DIFF
--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -310,20 +310,16 @@ end
 """
     elementinfo(ip::Interpolation; kwargs...)
     elementinfo(cell::AbstractCell; kwargs...)
+    elementinfo(ip::Type{Interpolation}; kwargs...)
+    elementinfo(cell::Type{AbstractCell}; kwargs...)
 
 - `plotnodes::Bool=true` plots the nodes as circles/spheres
 - `strokewidth::Int=2` how thick faces/edges are drawn
 - `color::Symbol=theme(scene,:linecolor)` color of the faces/edges and nodes
 - `markersize::Int=30` size of the nodes
-- `deformation_field::Symbol=:default` field that transforms the mesh by the given deformation, defaults to no deformation
-- `deformation_scale::Number=1.0` scaling of the deformation
-- `cellsets=false` Color cells based on their cellset association. If no cellset is found for a cell, the cell is marked blue.
 - `nodelables=false` global node id labels
 - `nodelabelcolor=:darkblue`
-- `celllabels=false` global cell id labels
-- `celllabelcolor=:darkred`
 - `textsize::Int=15` size of the label's text
-- `visible=true`
 """
 @recipe(Elementinfo) do scene
     Attributes(
@@ -335,7 +331,6 @@ end
     offset=(0.0,0.0),
     nodelabels=true,
     nodelabelcolor=:darkred,
-    celllabels=false,
     )
 end
 

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -323,7 +323,7 @@ end
 - `nodelabeloffset=(0.0,0.0)` offset of the nodelabel text relative to its associated node
 - `facelabels=true` switch that controls plotting of facelabels
 - `facelabelcolor=:darkgreen`
-- `facelabeloffset=(0,0)` offset of the facelabel text relative to its associated face middlepoint
+- `facelabeloffset=(-40,0)` offset of the facelabel text relative to its associated face middlepoint
 - `edgelabels=true` switch that controls plotting of edgelabels
 - `edgelabelcolor=:darkblue`
 - `edgelabeloffset=(-40,-40)` offset of the edgelabel text relative to its associated edge middlepoint
@@ -341,7 +341,7 @@ end
     nodelabeloffset=(0.0,0.0),
     facelabels=true,
     facelabelcolor=:darkgreen,
-    facelabeloffset=(0,0),
+    facelabeloffset=(-40,0),
     edgelabels=true,
     edgelabelcolor=:darkblue,
     edgelabeloffset=(-40,-40),

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -363,6 +363,7 @@ end
 
 Makie.convert_arguments(P::Type{<:Elementinfo}, cell::C) where C<:Ferrite.AbstractCell = (Ferrite.default_interpolation(typeof(cell)),)
 Makie.convert_arguments(P::Type{<:Elementinfo}, celltype::Type{C}) where C<:Ferrite.AbstractCell = (Ferrite.default_interpolation(celltype),)
+Makie.convert_arguments(P::Type{<:Elementinfo}, iptype::Type{IP}) where IP<:Ferrite.Interpolation = (iptype(),)
 
 """
     ferriteviewer(plotter::MakiePlotter)

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -313,13 +313,21 @@ end
     elementinfo(ip::Type{Interpolation}; kwargs...)
     elementinfo(cell::Type{AbstractCell}; kwargs...)
 
-- `plotnodes::Bool=true` plots the nodes as circles/spheres
-- `strokewidth::Int=2` how thick faces/edges are drawn
-- `color::Symbol=theme(scene,:linecolor)` color of the faces/edges and nodes
-- `markersize::Int=30` size of the nodes
-- `nodelables=false` global node id labels
-- `nodelabelcolor=:darkblue`
-- `textsize::Int=15` size of the label's text
+- `plotnodes=true` controls if nodes of element are plotted
+- `strokewidth=2` strokwidth of faces/edges
+- `color=theme(scene, :linecolor)`
+- `markersize=30` size of the nodes
+- `textsize=60` textsize of node-, edges- and facelabels
+- `nodelabels=true` switch that controls plotting of nodelabels
+- `nodelabelcolor=:darkred`
+- `nodelabeloffset=(0.0,0.0)` offset of the nodelabel text relative to its associated node
+- `facelabels=true` switch that controls plotting of facelabels
+- `facelabelcolor=:darkgreen`
+- `facelabeloffset=(0,0)` offset of the facelabel text relative to its associated face middlepoint
+- `edgelabels=true` switch that controls plotting of edgelabels
+- `edgelabelcolor=:darkblue`
+- `edgelabeloffset=(-40,-40)` offset of the edgelabel text relative to its associated edge middlepoint
+- `font="Julia Mono"` font of the node-, edge-, and facelabels
 """
 @recipe(Elementinfo) do scene
     Attributes(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -91,11 +91,11 @@ to_triangle(cell::Ferrite.AbstractCell{3,N,6}) where N = [Ferrite.vertices(cell)
 TODO this looks faulty...think harder.
 """
 # Helper to count triangles e.g. for preallocations.
-ntriangles(cell::Ferrite.AbstractCell{2,3,3}) where {N} = 1 # Tris in 2D
-ntriangles(cell::Ferrite.AbstractCell{3,3,1}) where {N} = 1 # Tris in 3D
+ntriangles(cell::Ferrite.AbstractCell{2,3,3}) = 1 # Tris in 2D
+ntriangles(cell::Ferrite.AbstractCell{3,3,1}) = 1 # Tris in 3D
 ntriangles(cell::Ferrite.AbstractCell{dim,N,4}) where {dim,N} = 4 # Quads in 2D and 3D
-ntriangles(cell::Ferrite.AbstractCell{3,N,1}) where {dim,N} = 4 # Tets as a special case of a Quad, obviously :)
-ntriangles(cell::Ferrite.AbstractCell{3,N,6}) where {dim,N} = 6*4 # Hex
+ntriangles(cell::Ferrite.AbstractCell{3,N,1}) where N = 4 # Tets as a special case of a Quad, obviously :)
+ntriangles(cell::Ferrite.AbstractCell{3,N,6}) where N = 6*4 # Hex
 
 """
 Get the vertices represented as a list of coordinates of a cell.
@@ -277,7 +277,7 @@ Transfer the solution of a plotter to the new mesh in 3D. We just evaluate the f
 
 @TODO Refactor. This is peak inefficiency.
 """
-function transfer_solution(plotter::MakiePlotter{3}, u::Vector; field_idx::Int=1, process::Function=FerriteViz.postprocess) where T
+function transfer_solution(plotter::MakiePlotter{3}, u::Vector; field_idx::Int=1, process::Function=FerriteViz.postprocess)
     n_vertices_per_tri = 3 # we have 3 vertices per triangle...
 
     # select objects from plotter


### PR DESCRIPTION
I'll include tomorrow or this evening the local face/edge numbering

`elementinfo` can be called by three different types of dispatches `::AbstractCell, ::Interpolation` or `::Type{AbstractCell}`. While writing it feels like `::Type{Interpolation}` should be dispatched too.
![grafik](https://user-images.githubusercontent.com/27497290/195994211-f8f74c17-c82a-403b-bd34-5e7a97377cfa.png)
