### PR TITLE
3D face renderer via FaceValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    parameters instead of the poisson number the Ansatz functions [#51][github-51].
 
 ### Fixed
+ - Visualization of non-conforming solution fields in 3D [#59][github-59].
  - An unknown bug has been fixed, which computes the colorbar `(min,max)` wrong. Now the `max` is
    set to be `1.01` of `min` guaranteeing that the value is larger than `min` if close to zero [#51][github-51].
  - Update Makie dependencies to fix some visualization bugs [#51][github-51].
@@ -32,3 +33,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [github-51](https://github.com/Ferrite-FEM/Ferrite.jl/pull/51)
 * [github-56](https://github.com/Ferrite-FEM/Ferrite.jl/pull/56)
 * [github-57](https://github.com/Ferrite-FEM/Ferrite.jl/pull/57)
+* [github-59](https://github.com/Ferrite-FEM/Ferrite.jl/pull/59)

--- a/docs/src/atopics.md
+++ b/docs/src/atopics.md
@@ -51,7 +51,7 @@ f
 
 An alternative to this approach is to compute gradient quantities at samples points and plot these via `arrows`.
 
-### High-order fields
+## High-order fields
 
 The investigation of high-order fields is currently only supported via a first-order refinment of the problem.
 Here, the high-order approximation is replaced by a first order approximation of the field, which is

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -359,16 +359,14 @@ function transfer_solution(plotter::MakiePlotter{3}, u::Vector; field_idx::Int=1
             face_geo = linear_face_cell(cell_geo, local_face_idx)
             # TODO Optimize for mixed geometries
             nfvertices = ntriangles(face_geo)*n_vertices_per_tri
-            ref_coords_face = [Tensors.Vec(ref_coords[current_vertex_index+i-1, :]...) for i in 1:nfvertices]
-
-            qr = Ferrite.QuadratureRule{3, refshape(face_geo), Float64}(ones(length(ref_coords_face)), ref_coords_face)
-
-            cv = (field_dim == 1) ? Ferrite.CellScalarValues(qr, ip_cell, ip_geo) : Ferrite.CellVectorValues(qr, ip_cell, ip_geo)
-            Ferrite.reinit!(cv, cell)
 
             # Loop over vertices
             for i in 1:nfvertices
-                val = Ferrite.function_value(cv, i, u[_local_celldofs])
+                qr = Ferrite.QuadratureRule{3, refshape(face_geo), Float64}([1.0], [Tensors.Vec(ref_coords[current_vertex_index, :]...)])
+                cv = (field_dim == 1) ? Ferrite.CellScalarValues(qr, ip_cell, ip_geo) : Ferrite.CellVectorValues(qr, ip_cell, ip_geo)
+                Ferrite.reinit!(cv, cell)
+                # val = Ferrite.function_value(cv, i, u[_local_celldofs])
+                val = Ferrite.function_value(cv, 1, u[_local_celldofs])
                 for d in 1:field_dim
                     data[current_vertex_index, d] += val[d] #current_vertex_index
                 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -376,7 +376,7 @@ function transfer_solution(plotter::MakiePlotter{3}, u::Vector; field_idx::Int=1
             end
         end
     end
-    @show data
+
     return mapslices(process, data, dims=[2])
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -284,7 +284,7 @@ Transfer the solution of a plotter to the new mesh in 2D.
 
 @TODO Refactor. This is peak inefficiency.
 """
-function transfer_solution(plotter::MakiePlotter{2}, u::Vector; field_idx::Int=1, process::Function=FerriteViz.postprocess)
+function transfer_solution(plotter::MakiePlotter{2,DH,T}, u::Vector; field_idx::Int=1, process::Function=FerriteViz.postprocess) where {DH<:Ferrite.AbstractDofHandler,T}
     n_vertices_per_tri = 3 # we have 3 vertices per triangle...
 
     # select objects from plotter
@@ -320,7 +320,7 @@ function transfer_solution(plotter::MakiePlotter{2}, u::Vector; field_idx::Int=1
             current_vertex_index += 1
         end
     end
-    return mapslices(process, data, dims=[2])
+    return mapslices(process, data, dims=[2])::Matrix{T}
 end
 
 """
@@ -328,7 +328,7 @@ Transfer the solution of a plotter to the new mesh in 3D.
 
 @TODO Refactor. This is peak inefficiency.
 """
-function transfer_solution(plotter::MakiePlotter{3}, u::Vector; field_idx::Int=1, process::Function=FerriteViz.postprocess)
+function transfer_solution(plotter::MakiePlotter{3,DH,T}, u::Vector; field_idx::Int=1, process::Function=FerriteViz.postprocess) where {DH<:Ferrite.AbstractDofHandler,T}
     n_vertices_per_tri = 3 # we have 3 vertices per triangle...
 
     # select objects from plotter
@@ -383,10 +383,10 @@ function transfer_solution(plotter::MakiePlotter{3}, u::Vector; field_idx::Int=1
         end
     end
 
-    return mapslices(process, data, dims=[2])
+    return mapslices(process, data, dims=[2])::Matrix{T}
 end
 
-function transfer_scalar_celldata(plotter::MakiePlotter{3}, u::Vector; process::Function=FerriteViz.postprocess)
+function transfer_scalar_celldata(plotter::MakiePlotter{3,DH,T}, u::Vector; process::Function=FerriteViz.postprocess) where {DH<:Ferrite.AbstractDofHandler,T}
     n_vertices = 3 # we have 3 vertices per triangle...
 
     # select objects from plotter
@@ -406,10 +406,10 @@ function transfer_scalar_celldata(plotter::MakiePlotter{3}, u::Vector; process::
         end
     end
 
-    return mapslices(process, data, dims=[2])
+    return mapslices(process, data, dims=[2])::Matrix{T}
 end
 
-function transfer_scalar_celldata(plotter::MakiePlotter{2}, u::Vector;  process::Function=FerriteViz.postprocess)
+function transfer_scalar_celldata(plotter::MakiePlotter{2,DH,T}, u::Vector;  process::Function=FerriteViz.postprocess) where {DH<:Ferrite.AbstractDofHandler,T}
     n_vertices = 3 # we have 3 vertices per triangle...
 
     # select objects from plotter
@@ -425,10 +425,10 @@ function transfer_scalar_celldata(plotter::MakiePlotter{2}, u::Vector;  process:
         end
     end
 
-    return mapslices(process, data, dims=[2])
+    return mapslices(process, data, dims=[2])::Matrix{T}
 end
 
-function transfer_scalar_celldata(grid::Ferrite.AbstractGrid{3}, num_vertices::Number, u::Vector; process::Function=FerriteViz.postprocess)
+function transfer_scalar_celldata(grid::Ferrite.AbstractGrid{3}, num_vertices::Number, u::Vector{T}; process::Function=FerriteViz.postprocess) where T
     n_vertices = 3 # we have 3 vertices per triangle...
     current_vertex_index = 1
     data = fill(0.0, num_vertices, 1)
@@ -442,10 +442,10 @@ function transfer_scalar_celldata(grid::Ferrite.AbstractGrid{3}, num_vertices::N
             end
         end
     end
-    return mapslices(process, data, dims=[2])
+    return mapslices(process, data, dims=[2])::Matrix{T}
 end
 
-function transfer_scalar_celldata(grid::Ferrite.AbstractGrid{2}, num_vertices::Number, u::Vector;  process::Function=FerriteViz.postprocess)
+function transfer_scalar_celldata(grid::Ferrite.AbstractGrid{2}, num_vertices::Number, u::Vector{T};  process::Function=FerriteViz.postprocess) where T
     n_vertices = 3 # we have 3 vertices per triangle...
     current_vertex_index = 1
     data = fill(0.0, num_vertices, 1)
@@ -455,7 +455,7 @@ function transfer_scalar_celldata(grid::Ferrite.AbstractGrid{2}, num_vertices::N
             current_vertex_index += 1
         end
     end
-    return mapslices(process, data, dims=[2])
+    return mapslices(process, data, dims=[2])::Matrix{T}
 end
 
 function dof_to_node(dh::Ferrite.AbstractDofHandler, u::Array{T,1}; field::Int=1, process::Function=postprocess) where T
@@ -474,7 +474,7 @@ function dof_to_node(dh::Ferrite.AbstractDofHandler, u::Array{T,1}; field::Int=1
             end
         end
     end
-    return mapslices(process, data, dims=[2])
+    return mapslices(process, data, dims=[2])::Matrix{T}
 end
 
 get_gradient_interpolation(::Ferrite.Lagrange{dim,shape,order}) where {dim,shape,order} = Ferrite.DiscontinuousLagrange{dim,shape,order-1}()


### PR DESCRIPTION
This PR changes the internal face renderer in 3D from a custom one to CellValues. Closes #58 . This is also the first step to ensures that clipping works properly in the future. 

Either this PR or FaceValues still has some kind of bug, because the rendering only works up to a permutation of the dofs. A minimal example with a hotfix is given here:

```julia
using Ferrite, FerriteViz, GLMakie

include("docs/src/ferrite-examples/heat-equation.jl");

dh,u=manufactured_heat_problem(Hexahedron, Lagrange{3,RefCube,2}(), 5);
(dh_grad, u_grad) = FerriteViz.interpolate_gradient_field(dh, u, :u);
plotter = FerriteViz.MakiePlotter(dh_grad,u_grad);
clip_plane = FerriteViz.ClipPlane(Ferrite.Vec((0.01,0.1,0.1)), 0.1);
clipped_plotter = FerriteViz.crincle_clip(plotter, clip_plane);
FerriteViz.solutionplot(clipped_plotter)
```

![Screenshot from 2023-02-15 03-31-53](https://user-images.githubusercontent.com/9196588/218912299-2f3fada5-22dc-4da4-9453-3a324d6a8b06.png)

This PR will need a follow up to increase performance, as this the implementation quite slow for now.