### PR TITLE
very basic culling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - Basic culling where all faces of all boundary elements are rendered ([#56][github-56])
+### Modified
+ - Removed unnecessary extra dispatches for three-dimensional case ([#56][github-56])
+### Fixed
+ - Renamed `Crincle` to `Crinkle` ([#56][github-56])
 
 ## [0.2.0] - 2023-03-06
 ### Added
@@ -35,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [github-56]: https://github.com/Ferrite-FEM/FerriteViz.jl/pull/56
 [github-57]: https://github.com/Ferrite-FEM/FerriteViz.jl/pull/57
 [github-59]: https://github.com/Ferrite-FEM/FerriteViz.jl/pull/59
+[github-63]: https://github.com/Ferrite-FEM/FerriteViz.jl/pull/63
 
 [Unreleased]: https://github.com/Ferrite-FEM/FerriteViz.jl/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/Ferrite-FEM/FerriteViz.jl/compare/v0.2.0...v0.1.4

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -3,6 +3,7 @@
 On this page the docs of the provided functions are listed
 
 ```@docs
+FerriteViz.MakiePlotter
 FerriteViz.solutionplot
 FerriteViz.cellplot
 FerriteViz.wireframe
@@ -12,4 +13,7 @@ FerriteViz.elementinfo
 FerriteViz.ferriteviewer
 FerriteViz.update!
 FerriteViz.for_discretization
+FerriteViz.crinkle_clip!
+FerriteViz.crinkle_clip
+FerriteViz.ClipPlane
 ```

--- a/docs/src/ferrite-examples/incompressible-elasticity.jl
+++ b/docs/src/ferrite-examples/incompressible-elasticity.jl
@@ -6,7 +6,7 @@ function create_cook_grid(nx, ny)
                Tensors.Vec{2}((48.0, 44.0)),
                Tensors.Vec{2}((48.0, 60.0)),
                Tensors.Vec{2}((0.0,  44.0))]
-    grid = generate_grid(Triangle, (nx, ny), corners);
+    grid = generate_grid(Quadrilateral, (nx, ny), corners);
     # facesets for boundary conditions
     addfaceset!(grid, "clamped", x -> norm(x[1]) ≈ 0.0);
     addfaceset!(grid, "traction", x -> norm(x[1]) ≈ 48.0);
@@ -15,11 +15,11 @@ end;
 
 function create_values(interpolation_u, interpolation_p)
     # quadrature rules
-    qr      = QuadratureRule{2,RefTetrahedron}(3)
-    face_qr = QuadratureRule{1,RefTetrahedron}(3)
+    qr      = QuadratureRule{2,RefCube}(3)
+    face_qr = QuadratureRule{1,RefCube}(3)
 
     # geometric interpolation
-    interpolation_geom = Lagrange{2,RefTetrahedron,1}()
+    interpolation_geom = Lagrange{2,RefCube,1}()
 
     # cell and facevalues for u
     cellvalues_u = CellVectorValues(qr, interpolation_u, interpolation_geom)
@@ -160,7 +160,7 @@ function solve(interpolation_u, interpolation_p, mp)
     u = Symmetric(K) \ f;
 
     # export
-    filename = "cook_" * (isa(interpolation_u, Lagrange{2,RefTetrahedron,1}) ? "linear" : "quadratic") *
+    filename = "cook_" * (isa(interpolation_u, Lagrange{2,RefCube,1}) ? "linear" : "quadratic") *
                          "_linear"
     vtk_grid(filename, dh) do vtkfile
         vtk_point_data(vtkfile, dh, u)
@@ -168,8 +168,8 @@ function solve(interpolation_u, interpolation_p, mp)
     return u,dh
 end
 
-linear    = Lagrange{2,RefTetrahedron,1}()
-quadratic = Lagrange{2,RefTetrahedron,2}()
+linear    = Lagrange{2,RefCube,1}()
+quadratic = Lagrange{2,RefCube,2}()
 
 ν = 0.4999999
 Emod = 1.

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -100,7 +100,7 @@ For a more granular investigation of the stress field consult the advanced tutor
 For 3D problems we can also inspect the interior of the domain. Currenly we only have crinkle clipping
 implemented and it can be used as follows:
 ```@example 1
-clip_plane = FerriteViz.ClipPlane(Vec((0.01,0.5,0.5)), 0.7)
+clip_plane = FerriteViz.ClipPlane(Vec((0.0,0.5,0.5)), 0.7)
 clipped_plotter = FerriteViz.crinkle_clip(plotter, clip_plane)
 FerriteViz.solutionplot(clipped_plotter,deformation_field=:u,colormap=:thermal,deformation_scale=2.0)
 WGLMakie.current_figure()

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -101,7 +101,7 @@ For 3D problems we can also inspect the interior of the domain. Currenly we only
 implemented and it can be used as follows:
 ```@example 1
 clip_plane = FerriteViz.ClipPlane(Vec((0.01,0.5,0.5)), 0.7)
-clipped_plotter = FerriteViz.crincle_clip(plotter, clip_plane)
+clipped_plotter = FerriteViz.crinkle_clip(plotter, clip_plane)
 FerriteViz.solutionplot(clipped_plotter,deformation_field=:u,colormap=:thermal,deformation_scale=2.0)
 WGLMakie.current_figure()
 ```

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -145,7 +145,7 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:MakiePlotter{dim}}}) where dim
     # u_matrix = @lift($(WF[:deformation_field])===:default ? zeros(0,3) : transfer_solution(plotter; field_idx=Ferrite.find_field(plotter.dh,$(WF[:deformation_field])), process=identity))
     # coords = @lift($(WF[:deformation_field])===:default ? plotter.physical_coords : plotter.physical_coords .+ ($(WF[:scale]) .* $(u_matrix)))
     #original representation
-    nodal_u_matrix = @lift($(WF[:deformation_field])===:default ? zeros(0,3) : dof_to_node(plotter.dh, $(WF[1][].u); field=Ferrite.find_field(plotter.dh,$(WF[:deformation_field]))))
+    nodal_u_matrix = @lift($(WF[:deformation_field])===:default ? zeros(0,3) : dof_to_node(plotter.dh, $(WF[1][].u); field=Ferrite.find_field(plotter.dh,$(WF[:deformation_field])), process=identity))
     gridnodes = @lift($(WF[:deformation_field])===:default ? plotter.gridnodes : plotter.gridnodes .+ ($(WF[:deformation_scale]) .* $(nodal_u_matrix)))
     lines = @lift begin
         dim > 2 ? (lines = Point3f[]) : (lines = Point2f[])

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -145,7 +145,7 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:MakiePlotter{dim}}}) where dim
     # u_matrix = @lift($(WF[:deformation_field])===:default ? zeros(0,3) : transfer_solution(plotter; field_idx=Ferrite.find_field(plotter.dh,$(WF[:deformation_field])), process=identity))
     # coords = @lift($(WF[:deformation_field])===:default ? plotter.physical_coords : plotter.physical_coords .+ ($(WF[:scale]) .* $(u_matrix)))
     #original representation
-    nodal_u_matrix = @lift($(WF[:deformation_field])===:default ? zeros(0,3) : dof_to_node(plotter.dh, $(WF[1][].u); field=Ferrite.find_field(plotter.dh,$(WF[:deformation_field])), process=identity))
+    nodal_u_matrix = @lift($(WF[:deformation_field])===:default ? zeros(0,3) : dof_to_node(plotter.dh, $(WF[1][].u); field=Ferrite.find_field(plotter.dh,$(WF[:deformation_field]))))
     gridnodes = @lift($(WF[:deformation_field])===:default ? plotter.gridnodes : plotter.gridnodes .+ ($(WF[:deformation_scale]) .* $(nodal_u_matrix)))
     lines = @lift begin
         dim > 2 ? (lines = Point3f[]) : (lines = Point2f[])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -467,6 +467,26 @@ function interpolate_gradient_field(dh::Ferrite.DofHandler{spatial_dim}, u::Abst
     return dh_gradient, u_gradient
 end
 
+# maps the dof vector in nodal order, only needed for wireframe nodal deformation (since we display the original nodes)
+function dof_to_node(dh::Ferrite.AbstractDofHandler, u::Vector{T}; field::Int=1) where T
+    fieldnames = Ferrite.getfieldnames(dh)
+    field_dim = Ferrite.getfielddim(dh, field)
+    data = fill(NaN, Ferrite.getnnodes(dh.grid), field_dim)
+    offset = Ferrite.field_offset(dh, fieldnames[field])
+
+    for cell in Ferrite.CellIterator(dh)
+        _celldofs = Ferrite.celldofs(cell)
+        counter = 1
+        for node in cell.nodes
+            for d in 1:field_dim
+                data[node, d] = u[_celldofs[counter + offset]]
+                counter += 1
+            end
+        end
+    end
+    return data::Matrix{T}
+end
+
 """
 Mapping from 2D triangle to 3D face of a tetrahedon.
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -34,7 +34,7 @@ linear_face_cell(cell::Ferrite.Cell{3,N,6}, local_face_idx::Int) where N = Ferri
 # Obtain the face interpolation on regular geometries.
 getfaceip(ip::Ferrite.Interpolation{dim, shape, order}, local_face_idx::Int) where {dim, shape <: Union{Ferrite.RefTetrahedron, Ferrite.RefCube}, order} = Ferrite.getlowerdim(ip)
 
-struct MakiePlotter{dim,DH<:Ferrite.AbstractDofHandler,T,TOP<:Ferrite.AbstractTopology} <: AbstractPlotter
+struct MakiePlotter{dim,DH<:Ferrite.AbstractDofHandler,T,TOP<:Union{Nothing,Ferrite.AbstractTopology}} <: AbstractPlotter
     dh::DH
     u::Makie.Observable{Vector{T}} # original solution on the original mesh (i.e. dh.mesh)
     topology::TOP
@@ -55,7 +55,7 @@ The triangulation acts as a "L2" triangulation, i.e. each triangle node is doubl
 For large 3D grids, prefer to use the second constructor if you have already a `topology`.
 Otherwise, it will be rebuilt which is time consuming.
 """
-function MakiePlotter(dh::Ferrite.AbstractDofHandler, u::Vector, topology::TOP) where {TOP<:Ferrite.AbstractTopology}
+function MakiePlotter(dh::Ferrite.AbstractDofHandler, u::Vector, topology::TOP) where {TOP<:Union{Nothing,Ferrite.AbstractTopology}}
     cells = Ferrite.getcells(dh.grid)
     dim = Ferrite.getdim(dh.grid)
     visible = zeros(Bool,length(cells))
@@ -90,7 +90,7 @@ function MakiePlotter(dh::Ferrite.AbstractDofHandler, u::Vector, topology::TOP) 
     end
     return MakiePlotter{dim,typeof(dh),eltype(u),typeof(topology)}(dh,Observable(u),topology,visible,gridnodes,physical_coords,triangles,triangle_cell_map,reference_coords);
 end
-MakiePlotter(dh,u) = MakiePlotter(dh,u,Ferrite.ExclusiveTopology(dh.grid.cells))
+MakiePlotter(dh,u) = MakiePlotter(dh,u,Ferrite.getdim(dh.grid) > 2 ? Ferrite.ExclusiveTopology(dh.grid.cells) : nothing)
 
 # triangle_to_cell -> visible -> triangle access
 visible(plotter::MakiePlotter{3}) = plotter.triangles[plotter.visible[plotter.triangle_cell_map],:]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -125,7 +125,7 @@ implicit description of the clipping surface. Here `decision_fun` takes the grid
 a cell index as input and returns whether the cell is visible or not.
 Note that chained calls to `crinkle_clip!` won't work.
 """
-function crinkle_clip!(plotter::MakiePlotter{3,DH,T}, decision_fun::FUN) where {DH,T,FUN<:Function}
+function crinkle_clip!(plotter::MakiePlotter{3,DH,T}, decision_fun::DF) where {DH,T,DF}
     dh = plotter.dh
     u = plotter.u
     grid = dh.grid

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -138,7 +138,12 @@ function crincle_clip(plotter::MakiePlotter{3,DH,T}, decision_fun) where {DH,T}
     end
 
     # Create a plotter with views on the data.
-    return MakiePlotter{3,DH,T}(dh, u, plotter.gridnodes,
+    return MakiePlotter{3,DH,T,typeof(plotter.topology)}(
+        dh,
+        u,
+        plotter.topology,
+        visible_triangles,
+        plotter.gridnodes,
         plotter.physical_coords,
         plotter.triangles[visible_triangles, :],
         plotter.triangle_cell_map[visible_triangles],

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -347,7 +347,7 @@ function transfer_solution(plotter::MakiePlotter{dim,DH,T}, u::Vector; field_idx
     localbuffer = zeros(T,field_dim)
     _local_coords = Ferrite.getcoordinates(grid,1)
     _local_celldofs = Ferrite.celldofs(dh,1)
-    _celldofs_field = reshape(_local_celldofs[local_dof_range], (field_dim, Ferrite.getnbasefunctions(ip_field)))
+    _celldofs_field = @view _local_celldofs[local_dof_range]
     _local_ref_coords = Tensors.Vec{dim}(ref_coords[1,:])
 
     for (isvisible,(cell_idx,cell_geo)) in zip(plotter.visible,enumerate(Ferrite.getcells(dh.grid)))
@@ -363,14 +363,14 @@ function transfer_solution(plotter::MakiePlotter{dim,DH,T}, u::Vector; field_idx
         #end
         Ferrite.getcoordinates!(_local_coords,grid,cell_idx)
         Ferrite.celldofs!(_local_celldofs,dh,cell_idx)
-        _celldofs_field = reshape(_local_celldofs[local_dof_range], (field_dim, Ferrite.getnbasefunctions(ip_field)))
+        _celldofs_field = @view _local_celldofs[local_dof_range]
         ncvertices = ntriangles(cell_geo)*n_vertices_per_tri
         # TODO replace this with a triangle-to-cell map.
         for i in 1:ncvertices
             _local_ref_coords = Tensors.Vec{dim}(@view(ref_coords[current_vertex_index,:]))
             Ferrite.reinit!(pv, _local_coords, _local_ref_coords)
-            val = process(Ferrite.function_value(pv, 1, u[_local_celldofs]))
-            for d in 1:field_dim
+            val = process(Ferrite.function_value(pv, 1, @view(u[_celldofs_field])))
+            for d in 1:_processreturn
                 data[current_vertex_index,d] = val[d]
             end
             current_vertex_index += 1
@@ -382,9 +382,6 @@ end
 
 function transfer_scalar_celldata(plotter::MakiePlotter{dim,DH,T}, u::Vector; process::FUN=FerriteViz.postprocess) where {dim,DH<:Ferrite.AbstractDofHandler,T,FUN<:Function}
     n_vertices_per_tri = 3 # we have 3 vertices per triangle...
-
-    boundaryfaces = findall(isempty,plotter.topology.face_neighbor)
-    boundaryelements = Ferrite.getindex.(boundaryfaces,1)
 
     # select objects from plotter
     dh = plotter.dh


### PR DESCRIPTION
- works not with clip plane currently
- reduces for 70^3 element grid the rendered triangles from 8_232_000  to 705_600, so only 8% which is still a bit too much, but at least larger meshes would be feasible with it
- more of a test, needs some further work


```
using Ferrite
import FerriteViz,GLMakie

include("docs/src/ferrite-examples/heat-equation.jl")
dh,u = manufactured_heat_problem(Hexahedron,Lagrange{3,RefCube,1}(),70)
plotter = FerriteViz.MakiePlotter(dh,u)
fig, ax, sp = FerriteViz.solutionplot(plotter)
```


from 60 to 6 seconds