### PR TITLE
transfer solution optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
- - Basic culling where all faces of all boundary elements are rendered ([#56][github-56])
+ - Basic culling where all faces of all boundary elements are rendered ([#56][github-56]).
  - Citation file ([#65](github-65))
 ### Modified
- - Removed unnecessary extra dispatches for three-dimensional case ([#56][github-56])
+ - Removed unnecessary extra dispatches for three-dimensional case ([#56][github-56]).
+ - function barrier for `transfer_solution` such that its closer to type groundedness ([#68][github-68]).
 ### Fixed
- - Renamed `Crincle` to `Crinkle` ([#56][github-56])
+ - Renamed `Crincle` to `Crinkle` ([#56][github-56]).
 
 ## [0.2.0] - 2023-03-06
 ### Added
@@ -44,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [github-59]: https://github.com/Ferrite-FEM/FerriteViz.jl/pull/59
 [github-65]: https://github.com/Ferrite-FEM/FerriteViz.jl/pull/65
 [github-63]: https://github.com/Ferrite-FEM/FerriteViz.jl/pull/63
+[github-68]: https://github.com/Ferrite-FEM/FerriteViz.jl/pull/68
 
 [Unreleased]: https://github.com/Ferrite-FEM/FerriteViz.jl/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/Ferrite-FEM/FerriteViz.jl/compare/v0.2.0...v0.1.4

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -297,10 +297,15 @@ midpoint(cell::Ferrite.AbstractCell{2,N,4}, points) where N = Point2f(0.5 * (poi
 midpoint(cell::Ferrite.AbstractCell{3,N,4}, points) where N = Point3f((1/4) * (points[cell.nodes[1],:] + points[cell.nodes[2],:] + points[cell.nodes[3],:] + points[cell.nodes[4],:]))
 midpoint(cell::Ferrite.AbstractCell{3,N,6}, points) where N = Point3f(0.5 * (points[cell.nodes[1],:] + points[cell.nodes[7],:]))
 
+"""
+    postprocess(node_values::Vector{T}) -> T
+Takes the nodal dof vector and maps it either to the scalar or to the
+euclidean norm (in the vectorial case)
+"""
 function postprocess(node_values)
     dim = length(node_values)
     if dim == 1
-        return node_values[1]
+        return node_values[1] #scalar values vectors with length 1
     else
         return sqrt(sum(node_values.^2))
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -337,7 +337,7 @@ function transfer_solution(plotter::MakiePlotter{dim,DH,T}, u::Vector; field_idx
     current_vertex_index = 1
 
     Ferrite.reinit!(pv, Ferrite.getcoordinates(grid,1), Tensors.Vec(ref_coords[current_vertex_index,:]...))
-    n_basefuncs = Ferrite.getnbasefunctions(pv)
+    n_basefuncs = Ferrite.getnbasefunctions(pv)::Int
     val_buffer = zeros(T,field_dim)
     val = process(val_buffer)
     for d in 1:field_dim
@@ -349,7 +349,7 @@ function transfer_solution(plotter::MakiePlotter{dim,DH,T}, u::Vector; field_idx
     localbuffer = zeros(T,field_dim)
     _local_coords = Ferrite.getcoordinates(grid,1)
     _local_celldofs = Ferrite.celldofs(dh,1)
-    _celldofs_field = reshape(_local_celldofs[local_dof_range], (field_dim, Ferrite.getnbasefunctions(ip_field)))
+    _celldofs_field = reshape(_local_celldofs[local_dof_range], (field_dim, n_basefuncs))
     _local_ref_coords = Tensors.Vec{dim}(ref_coords[1,:])
 
     for (isvisible,(cell_idx,cell_geo)) in zip(plotter.visible,enumerate(Ferrite.getcells(dh.grid)))
@@ -365,7 +365,7 @@ function transfer_solution(plotter::MakiePlotter{dim,DH,T}, u::Vector; field_idx
         #end
         Ferrite.getcoordinates!(_local_coords,grid,cell_idx)
         Ferrite.celldofs!(_local_celldofs,dh,cell_idx)
-        _celldofs_field = reshape(@view(_local_celldofs[local_dof_range]), (field_dim, Ferrite.getnbasefunctions(ip_field)))
+        _celldofs_field = reshape(@view(_local_celldofs[local_dof_range]), (field_dim, n_basefuncs))
         ncvertices = ntriangles(cell_geo)*n_vertices_per_tri
         # TODO replace this with a triangle-to-cell map.
         for i in 1:ncvertices


### PR DESCRIPTION
- introduce function barrier to remove type instability in `transfer_solution` associated with `ip_field::Interpolation`
- make `FerriteViz.postprocess` type stable
- remove unnecessary type annotations

| Commit  | transfer_solution             | solutionplot                |
|---------|-------------------------------|-----------------------------|
| master | 4.277s    0.663 GiB           | 53.078s  30.38GB|
| pr | 2.913s 0.439 GiB | 51.152s 29.94 GB |

The internal "kernel" for the transfer `_transfer_solution` is close to type grounded