### PR TITLE
Wedge support

### DIFF
--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -423,6 +423,8 @@ function Makie.plot!(Ele::Elementinfo{<:Tuple{<:Ferrite.Interpolation{dim,refsha
             idx = 4
         elseif refshape == Ferrite.RefTetrahedron && dim == 3
             idx = 3
+        elseif refshape == Ferrite.RefPrism && dim == 3
+            idx = length(face)
         else
             idx = 2
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -272,7 +272,7 @@ end
 Decompose volumetric objects via their faces.
 """
 function decompose!(coord_offset, coord_matrix, ref_coord_matrix, triangle_offset, triangle_matrix, grid, cell::Ferrite.AbstractCell{3,N,M}) where {N,M}
-    # Just 6 quadrilaterals :)
+    # Default decomposition just decomposes each face individually
     for face_index ∈ 1:M
         face_coord_offset = coord_offset
         (coord_offset, triangle_offset) = decompose!(coord_offset, coord_matrix, ref_coord_matrix, triangle_offset, triangle_matrix, grid, linear_face_cell(cell, face_index))
@@ -441,8 +441,7 @@ Compute the piecewise discontinuous gradient field for `field_name`. Returns the
 """
 function interpolate_gradient_field(dh::Ferrite.DofHandler{spatial_dim}, u::AbstractVector, field_name::Symbol) where {spatial_dim}
     # Get some helpers
-    field_idx = Ferrite.find_field(dh, field_name)
-    ip = Ferrite.getfieldinterpolation(dh, field_idx)
+    ip = Ferrite.getfieldinterpolation(dh, field_name)
 
     # Create dof handler for gradient field
     dh_gradient = Ferrite.DofHandler(getgrid(dh))
@@ -499,7 +498,7 @@ end
 # maps the dof vector in nodal order, only needed for wireframe nodal deformation (since we display the original nodes)
 function dof_to_node(dh::Ferrite.AbstractDofHandler, u::Vector{T}; field::Int=1) where T
     fieldnames = Ferrite.getfieldnames(dh)
-    field_dim = Ferrite.getfielddim(dh, field)
+    field_dim = Ferrite.getfielddim(dh, fieldnames[field])
     data = fill(NaN, Ferrite.getnnodes(dh.grid), field_dim)
     offset = Ferrite.field_offset(dh, fieldnames[field])
 
@@ -525,6 +524,19 @@ function transfer_quadrature_face_to_cell(point::AbstractVector, cell::Ferrite.A
     face == 2 && return [ y,  0,  1-x-y]
     face == 3 && return [ x,  y,  1-x-y]
     face == 4 && return [ 0,  1-x-y,  y]
+end
+
+"""
+Mapping from 2D quadrilateral/triangle to 3D face of a wedge.
+"""
+function transfer_quadrature_face_to_cell(point::AbstractVector, cell::Ferrite.AbstractCell{3,N,5}, face::Int) where {N}
+    # Note that for quadrilaterals the domain is [-1, 1]² but for triangles it is [0, 1]²
+    x,y = point
+    face == 1 && return [    1-x-y,         y,       0]
+    face == 2 && return [  (1+x)/2,         0, (1+y)/2]
+    face == 3 && return [        0, 1-(1+x)/2, (1+y)/2]
+    face == 4 && return [1-(1+x)/2,   (1+x)/2, (1+y)/2]
+    face == 5 && return [        y,     1-x-y,       1]
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,9 +20,7 @@ Ferrite.default_interpolation(::Type{Ferrite.Cell{3,3,1}}) = Ferrite.Lagrange{2,
 # Note: This extracts the face spanned by the vertices, not the actual face!
 linear_face_cell(cell::Ferrite.Cell{3,N,4}, local_face_idx::Int) where N =  Ferrite.Cell{3,3,1}(Ferrite.faces(cell)[local_face_idx])
 linear_face_cell(cell::Ferrite.Cell{3,N,6}, local_face_idx::Int) where N = Ferrite.Quadrilateral3D(Ferrite.faces(cell)[local_face_idx])
-
-# Obtain the face interpolation on regular geometries.
-getfaceip(ip::Ferrite.Interpolation{dim, shape, order}, local_face_idx::Int) where {dim, shape <: Union{Ferrite.RefTetrahedron, Ferrite.RefCube}, order} = Ferrite.getlowerdim(ip)
+linear_face_cell(cell::Ferrite.Cell{3,N,5}, local_face_idx::Int) where N = local_face_idx in 2:4 ? Ferrite.Quadrilateral3D(Ferrite.faces(cell)[local_face_idx]) : Ferrite.Cell{3,3,1}(Ferrite.faces(cell)[local_face_idx])
 
 struct MakiePlotter{dim,DH<:Ferrite.AbstractDofHandler,T1,TOP<:Union{Nothing,Ferrite.AbstractTopology},T2,M,TRI} <: AbstractPlotter
     dh::DH
@@ -182,6 +180,7 @@ ntriangles(cell::Ferrite.AbstractCell{3,3,1}) = 1 # Tris in 3D
 ntriangles(cell::Ferrite.AbstractCell{dim,N,4}) where {dim,N} = 4 # Quads in 2D and 3D
 ntriangles(cell::Ferrite.AbstractCell{3,N,1}) where N = 4 # Tets as a special case of a Quad, obviously :)
 ntriangles(cell::Ferrite.AbstractCell{3,N,6}) where N = 6*4 # Hex
+ntriangles(cell::Ferrite.AbstractCell{3,N,5}) where {N} = 1+4+4+4+1
 
 """
 Get the vertices represented as a list of coordinates of a cell.


### PR DESCRIPTION
Currently blocked by https://github.com/Ferrite-FEM/Ferrite.jl/issues/641 .

```julia
using Ferrite, FerriteViz, GLMakie
include("docs/src/ferrite-examples/heat-equation.jl")
dh,u = manufactured_heat_problem(Wedge, Lagrange{3,RefPrism,1}(), 5)
plotter = FerriteViz.MakiePlotter(dh,u)
clip_plane = FerriteViz.ClipPlane(Ferrite.Vec((0.01,0.5,0.1)), 0.3);
clipped_plotter = FerriteViz.crinkle_clip(plotter, clip_plane);
solutionplot(clipped_plotter)
```

![Screenshot from 2023-04-04 22-36-26](https://user-images.githubusercontent.com/9196588/229914522-96b34cd9-8326-41ee-a363-7ac0147834ca.png)
