### PR TITLE
bugfixes, ntriangles for higher order triangle and introduction of new kwarg `copy_fields` in `interpolategradient()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 
 [compat]
 Ferrite = "0.3"
+GeometryBasics = "0.4"
 Makie = "0.17,0.18,0.19"
 ShaderAbstractions = "0.3"
 Tensors = "1"

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -228,7 +228,8 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:MakiePlotter{dim}}}) where dim
     cellset_u =  reshape(transfer_scalar_celldata(plotter, cellset_u; process=identity), num_vertices(plotter))
     Makie.mesh!(WF, plotter.mesh, color=cellset_u, shading=false, scale_plot=false, colormap=:darktest, visible=WF[:cellsets])
     #plot the nodes
-    Makie.scatter!(WF,gridnodes,markersize=WF[:markersize], color=WF[:color], visible=WF[:plotnodes])
+    shouldplot = @lift ($(WF[:visible]) && $(WF[:plotnodes]))
+    Makie.scatter!(WF,gridnodes,markersize=WF[:markersize], color=WF[:color], visible=shouldplot)
     #set up nodelabels
     nodelabels = @lift $(WF[:nodelabels]) ? ["$i" for i in 1:size($gridnodes,1)] : [""]
     nodepositions = @lift $(WF[:nodelabels]) ? $gridnodes : (dim < 3 ? Point2f[Point2f((0,0))] : Point3f[Point3f((0,0,0))])
@@ -252,7 +253,8 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:Ferrite.AbstractGrid{dim}}}) where 
         append!(lines, [coords[e] for boundary in boundaryentities for e in boundary])
     end
     nodes = @lift($(WF[:plotnodes]) ? coords : Point3f[Point3f(0,0,0)])
-    Makie.scatter!(WF,nodes,markersize=WF[:markersize], color=WF[:color])
+    shouldplot = @lift ($(WF[:visible]) && $(WF[:plotnodes]))
+    Makie.scatter!(WF,nodes,markersize=WF[:markersize], color=WF[:color], visible=shouldplot)
     nodelabels = @lift $(WF[:nodelabels]) ? ["$i" for i in 1:size(coords,1)] : [""]
     nodepositions = @lift $(WF[:nodelabels]) ? coords : (dim < 3 ? Point2f[Point2f((0,0))] : Point3f[Point3f((0,0,0))])
     celllabels = @lift $(WF[:celllabels]) ? ["$i" for i in 1:Ferrite.getncells(grid)] : [""]
@@ -278,7 +280,7 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:Ferrite.AbstractGrid{dim}}}) where 
     Makie.mesh!(WF, plotter.mesh, color=cellset_u, shading=false, scale_plot=false, colormap=:darktest, visible=WF[:cellsets])
     Makie.text!(WF,nodelabels, position=nodepositions, textsize=WF[:textsize], offset=WF[:offset],color=WF[:nodelabelcolor])
     Makie.text!(WF,celllabels, position=cellpositions, textsize=WF[:textsize], color=WF[:celllabelcolor], align=(:center,:center))
-    Makie.linesegments!(WF,lines,color=WF[:color], strokewidth=WF[:strokewidth])
+    Makie.linesegments!(WF,lines,color=WF[:color], strokewidth=WF[:strokewidth], visible=WF[:visible])
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -177,8 +177,8 @@ num_vertices(p::MakiePlotter) = size(p.physical_coords,1)
 TODO this looks faulty...think harder.
 """
 # Helper to count triangles e.g. for preallocations.
-ntriangles(cell::Ferrite.AbstractCell{2,3,3}) = 1 # Tris in 2D
-ntriangles(cell::Ferrite.AbstractCell{3,3,1}) = 1 # Tris in 3D
+ntriangles(cell::Ferrite.AbstractCell{2,N,3}) where {N} = 1 # Tris in 2D
+ntriangles(cell::Ferrite.AbstractCell{3,N,1}) where {N} = 1 # Tris in 3D
 ntriangles(cell::Ferrite.AbstractCell{dim,N,4}) where {dim,N} = 4 # Quads in 2D and 3D
 ntriangles(cell::Ferrite.AbstractCell{3,N,1}) where N = 4 # Tets as a special case of a Quad, obviously :)
 ntriangles(cell::Ferrite.AbstractCell{3,N,6}) where N = 6*4 # Hex

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -440,7 +440,7 @@ This is a helper to access the correct value in Tensors.jl entities, because the
 
 Compute the piecewise discontinuous gradient field for `field_name`. Returns the flux dof handler and the corresponding flux dof values.
 """
-function interpolate_gradient_field(dh::Ferrite.DofHandler{spatial_dim}, u::AbstractVector, field_name::Symbol) where {spatial_dim}
+function interpolate_gradient_field(dh::Ferrite.DofHandler{spatial_dim}, u::AbstractVector, field_name::Symbol; copy_fields=Symbol[]) where {spatial_dim}
     # Get some helpers
     field_idx = Ferrite.find_field(dh, field_name)
     ip = Ferrite.getfieldinterpolation(dh, field_idx)
@@ -450,6 +450,12 @@ function interpolate_gradient_field(dh::Ferrite.DofHandler{spatial_dim}, u::Abst
     ip_gradient = get_gradient_interpolation(ip)
     field_dim = Ferrite.getfielddim(dh,field_name)
     push!(dh_gradient, :gradient, field_dim*spatial_dim, ip_gradient) # field dim × spatial dim components
+    for fieldname in copy_fields
+        _field_idx = Ferrite.find_field(dh, fieldname)
+        _ip = Ferrite.getfieldinterpolation(dh, _field_idx)
+        _field_dim = Ferrite.getfielddim(dh,fieldname)
+        push!(dh_gradient, fieldname, _field_dim, _ip)
+    end
     Ferrite.close!(dh_gradient)
 
     num_base_funs = Ferrite.getnbasefunctions(ip_gradient)
@@ -467,7 +473,7 @@ function interpolate_gradient_field(dh::Ferrite.DofHandler{spatial_dim}, u::Abst
     # Allocate storage for the fluxes to store
     u_gradient = zeros(Ferrite.ndofs(dh_gradient))
     # In general uᵉ_gradient is an order 3 tensor [field_dim, spatial_dim, num_base_funs]
-    uᵉ_gradient = zeros(length(cell_dofs_gradient))
+    uᵉ_gradient = zeros(length(cell_dofs_gradient[Ferrite.dof_range(dh_gradient, :gradient)]))
     uᵉ_gradient_view = reshape(uᵉ_gradient, (spatial_dim, field_dim, num_base_funs))
     uᵉ = zeros(field_dim*Ferrite.getnbasefunctions(ip))
 
@@ -492,7 +498,12 @@ function interpolate_gradient_field(dh::Ferrite.DofHandler{spatial_dim}, u::Abst
 
         # We finally write back the result to the global dof vector of the gradient field
         Ferrite.celldofs!(cell_dofs_gradient, dh_gradient, cell_num)
-        u_gradient[cell_dofs_gradient] .+= uᵉ_gradient
+        u_gradient[cell_dofs_gradient[Ferrite.dof_range(dh_gradient, :gradient)]] .+= uᵉ_gradient
+
+        # copy all requested fields
+        for fieldname in copy_fields
+            u_gradient[cell_dofs_gradient[Ferrite.dof_range(dh_gradient, fieldname)]] .= u[cell_dofs[Ferrite.dof_range(dh, fieldname)]]
+        end
     end
     return dh_gradient, u_gradient
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -439,7 +439,7 @@ This is a helper to access the correct value in Tensors.jl entities, because the
     interpolate_gradient_field(dh::DofHandler, u::AbstractVector, field_name::Symbol; copy_fields::Vector{Symbol})
 
 Compute the piecewise discontinuous gradient field for `field_name`. Returns the flux dof handler and the corresponding flux dof values.
-If the additional keyword argument `copy_fields` is provided with a non empty `Vector{Symbol}` the corresponding fields of `dh` will be
+If the additional keyword argument `copy_fields` is provided with a non empty `Vector{Symbol}`, the corresponding fields of `dh` will be
 copied into the returned flux dof handler and flux dof value vector.
 """
 function interpolate_gradient_field(dh::Ferrite.DofHandler{spatial_dim}, u::AbstractVector, field_name::Symbol; copy_fields::Vector{Symbol}=Symbol[]) where {spatial_dim}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -436,11 +436,13 @@ This is a helper to access the correct value in Tensors.jl entities, because the
 @inline _tensorsjl_gradient_accessor(m::Tensors.Tensor{2,dim}, field_dim_idx::Int, spatial_dim_idx::Int) where {dim} = m[field_dim_idx, spatial_dim_idx]
 
 """
-    interpolate_gradient_field(dh::DofHandler, u::AbstractVector, field_name::Symbol)
+    interpolate_gradient_field(dh::DofHandler, u::AbstractVector, field_name::Symbol; copy_fields::Vector{Symbol})
 
 Compute the piecewise discontinuous gradient field for `field_name`. Returns the flux dof handler and the corresponding flux dof values.
+If the additional keyword argument `copy_fields` is provided with a non empty `Vector{Symbol}` the corresponding fields of `dh` will be
+copied into the returned flux dof handler and flux dof value vector.
 """
-function interpolate_gradient_field(dh::Ferrite.DofHandler{spatial_dim}, u::AbstractVector, field_name::Symbol; copy_fields=Symbol[]) where {spatial_dim}
+function interpolate_gradient_field(dh::Ferrite.DofHandler{spatial_dim}, u::AbstractVector, field_name::Symbol; copy_fields::Vector{Symbol}=Symbol[]) where {spatial_dim}
     # Get some helpers
     field_idx = Ferrite.find_field(dh, field_name)
     ip = Ferrite.getfieldinterpolation(dh, field_idx)


### PR DESCRIPTION
- fixed some bugs in `src/makieploting.jl`
-  changed parametrization for ntriangles for higher order triangle (`ntriangles(cell::Ferrite.AbstractCell{2,3,3})  = 1` -> `ntriangles(cell::Ferrite.AbstractCell{2,N,3}) where {N} = 1`)
- introduced kwarg `copy_fields` to interpolategradient() which copies all selected fields of the DofHandler and all values of the node vector passed to the function to the returned DofHandler and and node vector. This way one can plot a gradient field in deformed state for example.