### PR TITLE
CI only on PRs and master

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,10 @@
 name: CI
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches: master
+    tags: '*'
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1', 'nightly']
+        julia-version: ['1.6', '1', 'nightly']
         os: ['ubuntu-latest']
         include:
           - os: windows-latest
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.version }}
+          version: ${{ matrix.julia-version }}
       - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,24 +12,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1.6'
-          - 'nightly'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
+        version: ['1.6', '1', 'nightly']
+        os: ['ubuntu-latest']
+        include:
+          - os: windows-latest
+            julia-version: '1'
+          - os: macOS-latest
+            julia-version: '1'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:
-          path: ~/.julia/artifacts
+          path: |
+            ~/.julia/artifacts
+            ~/.julia/packages
+            ~/.julia/registries
           key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
             ${{ runner.os }}-test-${{ env.cache-name }}-

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches:
-      - master
+    branches:  master
     tags: '*'
   pull_request:
 
@@ -11,10 +10,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.6'
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.julia/artifacts
+            ~/.julia/packages
+            ~/.julia/registries
+          key: .julia-docs-${{ hashFiles('docs/Project.toml', 'docs/Manifest.toml') }}
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy


### PR DESCRIPTION
Currently CI is triggered by every push, even on hidden branches. This adjusts the CI such that we only trigger the CI on master and PRs.