### PR TITLE
Use Makie.automatic for colorrange

### DIFF
--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -25,6 +25,7 @@ keyword arguments are:
 - `shading=false`
 - `scale_plot=false`
 - `transparent=false`
+- `nan_color::Union{Symbol, <:Colorant}=:red`
 """
 @recipe(SolutionPlot) do scene
     Attributes(
@@ -37,6 +38,7 @@ keyword arguments are:
     colorrange=Makie.automatic,
     transparent=false,
     deformation_scale = 1.0,
+    nan_color=:red,
     )
 end
 
@@ -65,7 +67,7 @@ function Makie.plot!(SP::SolutionPlot{<:Tuple{<:MakiePlotter}})
             plotter.physical_coords_mesh[1:end] = plotter.physical_coords .+ ($(SP[:deformation_scale]) .* $(u_matrix))
         end
     end
-    return Makie.mesh!(SP, plotter.mesh, color=solution, shading=SP[:shading], scale_plot=SP[:scale_plot], colormap=SP[:colormap],colorrange=SP[:colorrange] , transparent=SP[:transparent])
+    return Makie.mesh!(SP, plotter.mesh, color=solution, shading=SP[:shading], scale_plot=SP[:scale_plot], colormap=SP[:colormap],colorrange=SP[:colorrange] , transparent=SP[:transparent], nan_color=SP[:nan_color])
 end
 
 """
@@ -84,6 +86,7 @@ keyword arguments are:
 - `shading=false`
 - `scale_plot=false`
 - `transparent=false`
+- `nan_color::Union{Symbol, <:Colorant}=:red`
 """
 @recipe(CellPlot) do scene
     Attributes(
@@ -95,6 +98,7 @@ keyword arguments are:
     colorrange=Makie.automatic,
     transparent=false,
     deformation_scale = 1.0,
+    nan_color=:red,
     )
 end
 
@@ -116,7 +120,7 @@ function Makie.plot!(CP::CellPlot{<:Tuple{<:MakiePlotter{dim},Vector}}) where di
         end
     end
     solution =  @lift(reshape(transfer_scalar_celldata(plotter, qp_values; process=$(CP[:process])), num_vertices(plotter)))
-    return Makie.mesh!(CP, plotter.mesh, color=solution, shading=CP[:shading], scale_plot=CP[:scale_plot], colormap=CP[:colormap], transparent=CP[:transparent], colorrange=CP[:colorrange])
+    return Makie.mesh!(CP, plotter.mesh, color=solution, shading=CP[:shading], scale_plot=CP[:scale_plot], colormap=CP[:colormap], transparent=CP[:transparent], colorrange=CP[:colorrange], nan_color=CP[:nan_color])
 end
 
 """
@@ -298,6 +302,7 @@ values are transformed to a scalar based on `process` which defaults to the magn
 - `scale_plot = false`
 - `shading = false`
 - `colormap = :cividis`
+- `nan_color::Union{Symbol, <:Colorant}=:red`
 """
 @recipe(Surface) do scene
     Attributes(
@@ -306,6 +311,7 @@ values are transformed to a scalar based on `process` which defaults to the magn
     scale_plot = false,
     shading = false,
     colormap = :cividis,
+    nan_color=:red,
     )
 end
 
@@ -322,7 +328,7 @@ function Makie.plot!(SF::Surface{<:Tuple{<:MakiePlotter{2}}})
     coords = @lift begin
         Point3f[Point3f(coord[1], coord[2], $(solution)[idx]) for (idx, coord) in enumerate(plotter.physical_coords)]
     end
-    return Makie.mesh!(SF, coords, plotter.vis_triangles, color=solution, scale_plot=SF[:scale_plot], shading=SF[:shading], colormap=SF[:colormap])
+    return Makie.mesh!(SF, coords, plotter.vis_triangles, color=solution, scale_plot=SF[:scale_plot], shading=SF[:shading], colormap=SF[:colormap], nan_color=SF[:nan_color])
 end
 
 """

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -20,6 +20,7 @@ keyword arguments are:
 - `deformation_field::Symbol=:default` field that transforms the mesh by the given deformation, defaults to no deformation
 - `process::Function=postprocess` function to construct nodal scalar values from a vector valued problem
 - `colormap::Symbol=:cividis`
+- `colorrange::NTuple{2,<:Number}`: Specify (min, max) of the colorscale. If not given, min and max are calculated automatically from the data. 
 - `deformation_scale=1.0`
 - `shading=false`
 - `scale_plot=false`
@@ -78,6 +79,7 @@ keyword arguments are:
 - `deformation_field::Symbol=:default` field that transforms the mesh by the given deformation, defaults to no deformation
 - `process::Function=identity` function to construct cell scalar values. Defaults to `identity`, i.e. scalar values.
 - `colormap::Symbol=:cividis`
+- `colorrange::NTuple{2,<:Number}`: Specify (min, max) of the colorscale. If not given, min and max are calculated automatically from the data. 
 - `deformation_scale=1.0`
 - `shading=false`
 - `scale_plot=false`
@@ -90,7 +92,7 @@ keyword arguments are:
     deformation_field=:default,
     process=identity,
     colormap=:cividis,
-    colorrange=(0,1),
+    colorrange=Makie.automatic,
     transparent=false,
     deformation_scale = 1.0,
     )
@@ -113,11 +115,8 @@ function Makie.plot!(CP::CellPlot{<:Tuple{<:MakiePlotter{dim},Vector}}) where di
             plotter.physical_coords_mesh[1:end] = plotter.physical_coords .+ ($(CP[:deformation_scale]) .* $(u_matrix))
         end
     end
-    mins = minimum(qp_values)
-    maxs = maximum(qp_values)
-    CP[:colorrange] = @lift(isapprox($mins,$maxs) ? ($mins,1.01($maxs)) : ($mins,$maxs))
     solution =  @lift(reshape(transfer_scalar_celldata(plotter, qp_values; process=$(CP[:process])), num_vertices(plotter)))
-    return Makie.mesh!(CP, plotter.mesh, color=solution, shading=CP[:shading], scale_plot=CP[:scale_plot], colormap=CP[:colormap], transparent=CP[:transparent])
+    return Makie.mesh!(CP, plotter.mesh, color=solution, shading=CP[:shading], scale_plot=CP[:scale_plot], colormap=CP[:colormap], transparent=CP[:transparent], colorrange=CP[:colorrange])
 end
 
 """

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -33,7 +33,7 @@ keyword arguments are:
     deformation_field=:default,
     process=postprocess,
     colormap=:cividis,
-    colorrange=(0,1),
+    colorrange=Makie.automatic,
     transparent=false,
     deformation_scale = 1.0,
     )
@@ -62,19 +62,6 @@ function Makie.plot!(SP::SolutionPlot{<:Tuple{<:MakiePlotter}})
             plotter.physical_coords_mesh[1:end] = plotter.physical_coords
         else
             plotter.physical_coords_mesh[1:end] = plotter.physical_coords .+ ($(SP[:deformation_scale]) .* $(u_matrix))
-        end
-    end
-    mins = @lift(minimum(x->isnan(x) ?  1e10 : x, $solution))
-    maxs = @lift(maximum(x->isnan(x) ? -1e10 : x, $solution))
-    SP[:colorrange] = @lift begin
-        if isapprox($mins,$maxs)
-            if isapprox($mins,zero($mins)) && isapprox($maxs,zero($maxs))
-                (1e-18,2e-18)
-            else
-                ($mins,1.01($maxs))
-            end
-        else
-            ($mins,$maxs)
         end
     end
     return Makie.mesh!(SP, plotter.mesh, color=solution, shading=SP[:shading], scale_plot=SP[:scale_plot], colormap=SP[:colormap],colorrange=SP[:colorrange] , transparent=SP[:transparent])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -708,13 +708,13 @@ function uniform_refinement(plotter::MakiePlotter{dim,DH,T1,TOP,T2,M,TRI}) where
     n_visible = sum(plotter.visible[refined_triangle_cell_map])
     n_notvisible = length(refined_triangles) - n_visible
     refined_vis_triangles[ .! plotter.visible[refined_triangle_cell_map]] .= (GeometryBasics.GLTriangleFace(1,1,1) for i in 1:n_notvisible)
-    refined_vis_triangles = ShaderAbstractions.Buffer(Makie.Observable(refined_triangles))
+    refined_vis_triangles_m = ShaderAbstractions.Buffer(Makie.Observable(refined_vis_triangles))
     refined_physical_coords_m = ShaderAbstractions.Buffer(Makie.Observable(copy(refined_physical_coords)))
-    refined_mesh = GeometryBasics.Mesh(refined_physical_coords_m, refined_vis_triangles)
+    refined_mesh = GeometryBasics.Mesh(refined_physical_coords_m, refined_vis_triangles_m)
 
     return MakiePlotter{dim,DH,T1,TOP,T2,M,TRI}(
         plotter.dh, plotter.u, plotter.topology, plotter.visible, plotter.gridnodes,
-        refined_physical_coords, refined_physical_coords_m, refined_triangles, refined_vis_triangles, refined_triangle_cell_map,
+        refined_physical_coords, refined_physical_coords_m, refined_triangles, refined_vis_triangles_m, refined_triangle_cell_map,
         plotter.cell_triangle_offsets .* 4, refined_reference_coords, refined_mesh
     )
 end


### PR DESCRIPTION
supersedes #119, thanks for the tip @termi-official on `Makie.automatic` (haven't checked if this introduces new compat requirements)

Reproducer
```
using Ferrite, FerriteViz
import GLMakie as Plt

grid = generate_grid(Quadrilateral, (2, 2))

dh = DofHandler(grid)
add!(dh, :u, 1, Lagrange{2,RefCube,1}())
close!(dh)

a = zeros(ndofs(dh))

apply_analytical!(a, dh, :u, x -> rand() - 0.5) # ∈ [-0.5, 0.5]

plotter = MakiePlotter(dh, a)

fig = Plt.Figure()
ax = Plt.Axis(fig[1,1])
sp = solutionplot!(ax, plotter; colorrange=(-1.0, 1.0))
Plt.Colorbar(fig[1,2], sp)
fig
```

master (colorrange [-1, 1] not respected):
![master](https://github.com/Ferrite-FEM/FerriteViz.jl/assets/19473844/bb9e2f00-59a2-428a-b619-8506afabaf66)

pr (colorrange [-1, 1] respected)
![pr](https://github.com/Ferrite-FEM/FerriteViz.jl/assets/19473844/0fe1cc96-d364-4d47-be91-26f0a119057c)
