### PR TITLE
Tag v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-28
+
 Full rewrite of the internals around a ParaView-style pipeline:
-Source (`FEData`) → Filters → Representations. Breaking; to be tagged as a
-new minor release.
+Source (`FEData`) → Filters → Representations. Breaking release.
 
 ### Added
  - `FEData` data source with named point-/cell-data arrays
@@ -212,7 +213,8 @@ new minor release.
 [github-118]: https://github.com/Ferrite-FEM/FerriteViz.jl/issues/118
 [github-146]: https://github.com/Ferrite-FEM/FerriteViz.jl/pull/146
 
-[Unreleased]: https://github.com/Ferrite-FEM/FerriteViz.jl/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/Ferrite-FEM/FerriteViz.jl/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/Ferrite-FEM/FerriteViz.jl/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/Ferrite-FEM/FerriteViz.jl/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Ferrite-FEM/FerriteViz.jl/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Ferrite-FEM/FerriteViz.jl/compare/v0.2.1...v0.2.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FerriteViz"
 uuid = "59d0093e-b1f1-4fb7-ac85-ab57e45f39d9"
 authors = ["Maximilian Köhler <maximilian.koehler@ruhr-uni-bochum.de> and contributors"]
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
 Ferrite = "c061ca5d-56c9-439f-9c0e-210fe06d3992"

--- a/README.md
+++ b/README.md
@@ -40,13 +40,20 @@ For a guide check out [the tutorial section](https://ferrite-fem.github.io/Ferri
 ## Features
 
 - composable, reactive filters: `WarpByVector`, `Gradient`, `CrinkleClip`, `Refine`,
-  `FirstOrderRefinement`, `VonMises`, `Deviator`, `Threshold`, `Derive`, ...
+  `FirstOrderRefinement`, `ExtractComponent`, `Magnitude`, `Norm1`, `VonMises`, `Deviator`,
+  `Threshold`, `Derive`, ...
+- `AddQuadraturePointData` renders internal variables — data known only at the quadrature points —
+  by partitioning every cell into the exact Voronoi regions of its quadrature points, without
+  averaging over the cell or smoothing onto a nodal field
 - `solutionplot` FE solution contour plot on arbitrary finite element mesh (in Makie called `mesh` plots)
-- `ferriteviewer` viewer with toggles and menus that update the plot
+- `ferriteviewer` viewer with toggles and menus that update the plot, composable through a
+  `layout(ds, state)` hook and pluggable `Control`s
 - `meshplot` plots the finite element mesh and optionally labels nodes and cells
 - `arrowplot` - also called `quiver` plots, in paraview `glyph` filter
 - `surfaceplot` 2D solutions in 3D space as surface, in paraview `warp by scalar` filter
 - custom cell types via a single `reference_tessellation` method
+- `Wedge` and `Pyramid` cells out of the box, and curved (higher-order geometry) cells that
+  tessellate through their geometric interpolation
 - synchronous plotting while your simulation runs with any of the above listed options
 - mutating versions of the above listed functions (except for the viewer)
 - full integration into the Makie ecosystem, e.g. themes, layouts etc. 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,6 +21,10 @@ the `FEData` constructor
 ds = FEData(dh,u)
 ```
 
+Besides the dof fields, an `FEData` carries named point- and cell-data arrays
+([`FerriteViz.set_point_data!`](@ref), [`FerriteViz.set_cell_data!`](@ref)); filters read and
+write them by name, and every plot can be colored by any of them.
+
 Now, you can use `solutionplot`, `meshplot`, `arrowplot`, `surfaceplot` or the viewer via `ferriteviewer` —
 and compose transformations ParaView-style by piping the data through filters:
 
@@ -36,17 +40,26 @@ This package offers a set of unique features that are not easily reproducible wi
 
 - a composable, reactive filter pipeline (ParaView's Source → Filter → Representation model):
   [`FerriteViz.WarpByVector`](@ref), [`FerriteViz.Gradient`](@ref), [`FerriteViz.CrinkleClip`](@ref),
-  [`FerriteViz.Refine`](@ref), [`FerriteViz.FirstOrderRefinement`](@ref), [`FerriteViz.VonMises`](@ref),
+  [`FerriteViz.Refine`](@ref), [`FerriteViz.FirstOrderRefinement`](@ref), [`FerriteViz.ExtractComponent`](@ref),
+  [`FerriteViz.Magnitude`](@ref), [`FerriteViz.Norm1`](@ref), [`FerriteViz.VonMises`](@ref),
   [`FerriteViz.Deviator`](@ref), [`FerriteViz.Threshold`](@ref), [`FerriteViz.Derive`](@ref), ...
+- [`FerriteViz.AddQuadraturePointData`](@ref) renders internal variables — data known only at the
+  quadrature points, with no interpolation defining it elsewhere — by partitioning every cell into
+  the exact Voronoi regions of its quadrature points, so the values are neither averaged over the
+  cell nor smoothed onto a nodal field
 - [`FerriteViz.solutionplot`](@ref) FE solution contour plot on arbitrary finite element mesh (in Makie called `mesh` plots)
-- [`FerriteViz.ferriteviewer`](@ref) viewer with toggles and menus that update the plot
+- [`FerriteViz.ferriteviewer`](@ref) viewer with toggles and menus that update the plot, composable
+  through a `layout(ds, state)` hook and pluggable [`FerriteViz.Control`](@ref)s
 - [`FerriteViz.meshplot`](@ref) plots the finite element mesh and optionally labels nodes and cells
 - [`FerriteViz.arrowplot`](@ref) - also called `quiver` plots, in paraview `glyph` filter
 - [`FerriteViz.surfaceplot`](@ref) 2D solutions in 3D space as surface, in paraview `warp by scalar` filter
 - synchronous plotting while your simulation runs with any of the above listed options
 - mutating versions of the above listed functions (except for the viewer)
 - deformed plots for any representation via the [`FerriteViz.WarpByVector`](@ref) filter
-- support for custom cell types by implementing a single method (see the devdocs)
+- support for custom cell types by implementing a single [`FerriteViz.reference_tessellation`](@ref)
+  method (walked through on the [custom cells](cohesive.md) page)
+- `Wedge` and `Pyramid` cells out of the box, and curved (higher-order geometry) cells that
+  tessellate through their geometric interpolation
 - full integration into the Makie ecosystem, e.g. themes, layouts etc. 
 - GPU powered plotting with GLMakie.jl, jupyter/pluto notebook plotting with WGLMakie.jl and vector graphics with CairoMakie.jl
 - visualization of high order solutions via first order refinement


### PR DESCRIPTION
Tags the pipeline rewrite (#150) plus the CairoMakie fix (#146) as **v0.3.0**.

### Version
- `Project.toml`: `0.2.3` → `0.3.0`
- `CHANGELOG.md`: the `[Unreleased]` section is closed as `[0.3.0] - 2026-07-28`, a fresh empty `[Unreleased]` is opened, and the compare links are updated.

### Landing page audit
Checked `README.md` and `docs/src/index.md` against the refactor. Neither referenced removed API (no `MakiePlotter`, `field=`, `deformation_field=`, `process=`, `crinkle_clip`, `uniform_refinement`, `wireframe`, `arrows`) — they were kept in sync during the rewrite. What was missing were features the rewrite *added*, now listed on both pages:

- `AddQuadraturePointData` (Voronoi rendering of internal variables) — arguably the most distinctive new feature, mentioned on neither page
- the `ExtractComponent`, `Magnitude` and `Norm1` filters, missing from both filter lists
- the viewer's composability: the `layout(ds, state)` hook and pluggable `Control`s
- `Wedge`/`Pyramid` support and curved (higher-order geometry) cells
- `FEData`'s named point-/cell-data arrays, in the docs "Getting Started" section
- a link from the index feature list to the *Custom Cells* page (it previously only pointed at the devdocs)

All new `@ref` targets were verified to have `@docs` blocks (`api.md`, and `reference_tessellation` in `devdocs.md`).

No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)