### PR TITLE
Give TagBot contents: write permission

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -8,6 +8,8 @@ jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:


### PR DESCRIPTION
Fixes #157.

TagBot failed to create the `v0.3.0` release because the workflow declares no `permissions:` block, so `GITHUB_TOKEN` inherits the repository default (read-only) and cannot create releases. The tag itself was pushed fine via `DOCUMENTER_KEY`, which is why only the release was missing.

- `v0.3.0` release created manually: https://github.com/Ferrite-FEM/FerriteViz.jl/releases/tag/v0.3.0 (annotated tag `v0.3.0` → `6f0a236`, unchanged)
- This PR adds `permissions: contents: write` to the TagBot job so the next release works unattended.

Checked Ferrite.jl's `TagBot.yml` first — it is byte-for-byte identical to ours, missing `permissions:` too, so there was nothing newer to copy. It likely has the same latent problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)