### PR TITLE
Draw from observables on non-GLMakie backends, not ShaderAbstractions.Buffer

### DIFF
--- a/src/representations.jl
+++ b/src/representations.jl
@@ -17,13 +17,14 @@ end
 # The pipeline shares its coordinates and triangles into `ShaderAbstractions.Buffer`s
 # so GLMakie can mutate the GPU data in place on `update!` — and only GLMakie:
 # CairoMakie's software mesh path expects plain `Vector`s and does not accept a
-# `Buffer` for the faces, and WGLMakie's serialization sends the `Buffer` to JS
-# as-is, where THREE rejects it ("Unsupported buffer data format"). On every
-# backend but GLMakie we therefore draw from the coordinate *Observable* the
-# buffer wraps (`ds.coords`) plus the triangles' underlying vector: coordinate
-# and color updates then flow through Makie's ordinary observable path (live
-# WGLMakie viewers keep updating over the websocket); only CrinkleClip-style
-# *triangle* changes need the buffer link and won't propagate outside GLMakie.
+# `Buffer` for the faces, and WGLMakie renders a `Buffer`-backed mesh once but
+# never applies subsequent `Buffer` updates — the browser silently keeps the
+# initial geometry (verified on WGLMakie 0.13.13). On every backend but
+# GLMakie we therefore draw from the coordinate *Observable* the buffer wraps
+# (`ds.coords`) plus the triangles' underlying vector: coordinate and color
+# updates then flow through Makie's ordinary observable path (live WGLMakie
+# viewers keep updating over the websocket); only CrinkleClip-style *triangle*
+# changes need the buffer link and won't propagate outside GLMakie.
 function _is_glmakie_backend()
     backend = Makie.current_backend()
     return !ismissing(backend) && nameof(backend) === :GLMakie

--- a/src/representations.jl
+++ b/src/representations.jl
@@ -12,37 +12,39 @@ function base_fe_attributes()
     )
 end
 
-# Backend shim for CairoMakie (Petur Bryde, #146, fixes #118).
+# Backend shim, generalizing the CairoMakie one (Petur Bryde, #146, fixes #118).
 #
 # The pipeline shares its coordinates and triangles into `ShaderAbstractions.Buffer`s
-# so GL/WGLMakie can mutate the GPU data in place on `update!`. CairoMakie's
-# software mesh path, however, expects plain `Vector`s and does not accept a
-# `Buffer` for the faces. When CairoMakie is the active backend we therefore
-# draw from the buffers' underlying vectors instead of the buffer-backed
-# `GeometryBasics.Mesh` (CairoMakie renders a static frame, so losing the live
-# buffer link is inconsequential — `data()` still returns the vector kept in
-# sync with the coordinate observable).
-function _is_cairomakie_backend()
+# so GLMakie can mutate the GPU data in place on `update!` — and only GLMakie:
+# CairoMakie's software mesh path expects plain `Vector`s and does not accept a
+# `Buffer` for the faces, and WGLMakie's serialization sends the `Buffer` to JS
+# as-is, where THREE rejects it ("Unsupported buffer data format"). On every
+# backend but GLMakie we therefore draw from the coordinate *Observable* the
+# buffer wraps (`ds.coords`) plus the triangles' underlying vector: coordinate
+# and color updates then flow through Makie's ordinary observable path (live
+# WGLMakie viewers keep updating over the websocket); only CrinkleClip-style
+# *triangle* changes need the buffer link and won't propagate outside GLMakie.
+function _is_glmakie_backend()
     backend = Makie.current_backend()
-    return !ismissing(backend) && nameof(backend) === :CairoMakie
+    return !ismissing(backend) && nameof(backend) === :GLMakie
 end
 
 _buffer_data(x) = x
 _buffer_data(x::ShaderAbstractions.Buffer) = ShaderAbstractions.data(x)
 
 function _mesh!(parent, ds::FEData; kwargs...)
-    if _is_cairomakie_backend()
-        return Makie.mesh!(parent, _buffer_data(ds.coords_buffer), _buffer_data(ds.vis_triangles); kwargs...)
-    else
+    if _is_glmakie_backend()
         return Makie.mesh!(parent, ds.mesh; kwargs...)
+    else
+        return Makie.mesh!(parent, ds.coords, _buffer_data(ds.vis_triangles); kwargs...)
     end
 end
 
 function _mesh!(parent, vertices, faces; kwargs...)
-    if _is_cairomakie_backend()
-        return Makie.mesh!(parent, vertices, _buffer_data(faces); kwargs...)
-    else
+    if _is_glmakie_backend()
         return Makie.mesh!(parent, vertices, faces; kwargs...)
+    else
+        return Makie.mesh!(parent, vertices, _buffer_data(faces); kwargs...)
     end
 end
 


### PR DESCRIPTION
## Problem

The pipeline shares coordinates and triangles into `ShaderAbstractions.Buffer`s
so GLMakie can mutate GPU data in place on `update!`. Outside GLMakie that
mechanism doesn't work:

- **CairoMakie** rejects a `Buffer` for the faces outright — already shimmed in
  #146 (fixes #118);
- **WGLMakie** renders a `Buffer`-backed mesh once, but **silently ignores
  every subsequent `Buffer` update** — the browser keeps the initial geometry,
  so live viewers (time sliders, watchers, deformation toggles) freeze while
  color updates (which travel as plain observables) keep flowing.

Isolation test for the WGLMakie half: two `mesh!` plots driven by the *same*
position `Observable`, one through `GeometryBasics.Mesh(Buffer(pos),
Buffer(faces))`, one as `mesh!(ax, pos, faces)`. Toggling `pos[]` moves only
the plain-observable mesh; the buffer-backed one never moves (WGLMakie
0.13.13 / Makie 0.24.13). A corresponding WGLMakie issue is being filed.

https://github.com/MakieOrg/Makie.jl/issues/5719
https://github.com/MakieOrg/Makie.jl/issues/5720

## Fix

Invert the backend shim from #146: only GLMakie consumes `Buffer`s natively,
so it keeps the buffer-backed mesh; **every other backend** now draws from the
coordinate `Observable` the buffer wraps (`ds.coords`) plus the triangles'
underlying vector.

Compared to extending the CairoMakie special case backend-by-backend, drawing
from the observable keeps the live-update path on WGLMakie: coordinate and
color updates flow through Makie's ordinary observable pipeline and stream to
open browser viewers over the websocket. Verified interactively — a live
viewer (time slider + field menu over quadrature-point data) renders and
updates in WGLMakie with this patch.

## Limitation

*Triangle* updates (`CrinkleClip`-style visibility changes) ride the buffer
link and therefore only propagate on GLMakie, as before — the faces are handed
over as a plain vector snapshot. Coordinate/color updates are unaffected.

CairoMakie behavior is unchanged in substance (it now receives the coordinate
observable instead of the raw vector, which `Makie.mesh!` accepts either way);
CairoMakie snapshot output was regression-checked pixel-identical.

## Note for testing in WGLMakie

WGLMakie ≤ 0.13.13 has an **unrelated** bug that blanks the canvas with
`THREE.WebGLAttributes: Unsupported buffer data format`: a colormap `Sampler`
is misclassified as a per-vertex buffer whenever the LUT length (256)
coincides with the mesh vertex count (e.g. a 16-cell quadrilateral
quadrature-point tessellation → exactly 256 vertices). Being reported to
Makie separately; `Makie.is_scalar_attribute(::ShaderAbstractions.Sampler) =
true` works around it. Without that workaround a 256-vertex test mesh stays
blank regardless of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
